### PR TITLE
Add an option to render off-screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Recommended to enable if
 
 If enabled, since the order of rendering sources changes, something might be affected.
 
-If no issues are reported with disabling this property, this property might be dropped in the future and fixed to enabled.
+If no issues are reported without disabling this property, this property might be dropped in the future and fixed to enabled. If you need this property, please file an issue not to deprecate.
 
 ## Build and install
 ### Linux

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Enable this setting if one of these conditions applies.
 - You want to hide overflowing scene items outside the bounding box of the main view.
 - You want to put the source on the main view to enjoy fractals.
 
+### Render before output/display rendering
+
+*Deprecated*
+
+Render the texture before OBS start to render output and each display.
+Recommended to enable if
+- You want to have the source in a nested scene.
+
+If enabled, since the order of rendering sources changes, something might be affected.
+
+If no issues are reported with disabling this property, this property might be dropped in the future and fixed to enabled.
+
 ## Build and install
 ### Linux
 Use cmake to build on Linux. After checkout, run these commands.

--- a/src/main-view-source.c
+++ b/src/main-view-source.c
@@ -40,7 +40,6 @@ static obs_properties_t *get_properties(void *data)
 	obs_property_t *prop;
 
 	prop = obs_properties_add_bool(props, "cache", obs_module_text("Cache the main view"));
-	// TODO: set modified callback and toggle availability of offsceeen_render
 	obs_properties_add_bool(props, "offsceeen_render", obs_module_text("Render before output/display rendering"));
 
 	obs_property_set_modified_callback(prop, cache_modified);

--- a/src/main-view-source.c
+++ b/src/main-view-source.c
@@ -5,6 +5,7 @@
 
 struct main_view_s
 {
+	obs_source_t *context;
 	bool rendering;
 
 	obs_weak_source_t *weak_source;
@@ -15,6 +16,7 @@ struct main_view_s
 
 	// properties
 	bool cache;
+	bool offsceeen_render;
 };
 
 static const char *get_name(void *type_data)
@@ -23,14 +25,44 @@ static const char *get_name(void *type_data)
 	return obs_module_text("Main View Source");
 }
 
+static bool cache_modified(obs_properties_t *props, obs_property_t *property, obs_data_t *settings)
+{
+	bool cache = obs_data_get_bool(settings, "cache");
+	obs_property_t *offsceeen_render = obs_properties_get(props, "offsceeen_render");
+	obs_property_set_enabled(offsceeen_render, cache);
+	return true;
+}
+
 static obs_properties_t *get_properties(void *data)
 {
 	UNUSED_PARAMETER(data);
 	obs_properties_t *props = obs_properties_create();
+	obs_property_t *prop;
 
-	obs_properties_add_bool(props, "cache", obs_module_text("Cache the main view"));
+	prop = obs_properties_add_bool(props, "cache", obs_module_text("Cache the main view"));
+	// TODO: set modified callback and toggle availability of offsceeen_render
+	obs_properties_add_bool(props, "offsceeen_render", obs_module_text("Render before output/display rendering"));
+
+	obs_property_set_modified_callback(prop, cache_modified);
 
 	return props;
+}
+
+static void get_defaults(obs_data_t *defaults)
+{
+	obs_data_set_default_bool(defaults, "offsceeen_render", true);
+}
+
+static void main_view_offscreen_render_cb(void *data, uint32_t cx, uint32_t cy);
+
+static void register_offscreen_render(struct main_view_s *s)
+{
+	obs_add_main_render_callback(main_view_offscreen_render_cb, s);
+}
+
+static void unregister_offscreen_render(struct main_view_s *s)
+{
+	obs_remove_main_render_callback(main_view_offscreen_render_cb, s);
 }
 
 static void update(void *data, obs_data_t *settings)
@@ -38,14 +70,22 @@ static void update(void *data, obs_data_t *settings)
 	struct main_view_s *s = data;
 
 	s->cache = obs_data_get_bool(settings, "cache");
+	bool offsceeen_render = obs_data_get_bool(settings, "offsceeen_render") & s->cache;
+
+	if (offsceeen_render && !s->offsceeen_render)
+		register_offscreen_render(s);
+	else if (!offsceeen_render && s->offsceeen_render)
+		unregister_offscreen_render(s);
+	s->offsceeen_render = offsceeen_render;
 }
 
 static void *create(obs_data_t *settings, obs_source_t *source)
 {
 	UNUSED_PARAMETER(settings);
-	UNUSED_PARAMETER(source);
 
 	struct main_view_s *s = bzalloc(sizeof(struct main_view_s));
+
+	s->context = source;
 
 	update(s, settings);
 
@@ -61,6 +101,8 @@ static void destroy(void *data)
 	gs_texrender_destroy(s->texrender);
 	gs_texrender_destroy(s->texrender_prev);
 	obs_leave_graphics();
+	if (s->offsceeen_render)
+		unregister_offscreen_render(s);
 
 	bfree(s);
 }
@@ -130,6 +172,28 @@ static void render_cached_video(struct main_view_s *s)
 	gs_blend_state_pop();
 }
 
+static void main_view_offscreen_render_cb(void *data, uint32_t cx, uint32_t cy)
+{
+	UNUSED_PARAMETER(cx);
+	UNUSED_PARAMETER(cy);
+	struct main_view_s *s = data;
+
+	/* If the source has already been rendered, for example by Source Record, do nothing. */
+	if (s->rendered)
+		return;
+
+	if (!obs_source_showing(s->context))
+		return;
+
+	obs_source_t *target = obs_weak_source_get_source(s->weak_source);
+	if (target) {
+		s->rendering = true;
+		cache_video(s, target);
+		obs_source_release(target);
+		s->rendering = false;
+	}
+}
+
 static void video_render(void *data, gs_effect_t *effect)
 {
 	UNUSED_PARAMETER(effect);
@@ -192,6 +256,7 @@ const struct obs_source_info main_view_source = {
 	.create = create,
 	.destroy = destroy,
 	.get_properties = get_properties,
+	.get_defaults = get_defaults,
 	.update = update,
 	.video_tick = video_tick,
 	.video_render = video_render,


### PR DESCRIPTION
When main view source is put on a scene `Scene 1` and another scene `Scene 2` has `Scene 1`, the main view source was not correctly rendered.

Original purpose for the source is sending the main view to Source Record or NDI Dedicated Output. I put this as an enhancement.

Fix another issue #1.

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
