### PR TITLE
Do not render twice or more in one frame

### DIFF
--- a/src/main-view-source.c
+++ b/src/main-view-source.c
@@ -31,8 +31,6 @@ static obs_properties_t *get_properties(void *data)
 	return props;
 }
 
-static void get_defaults(obs_data_t *defaults) {}
-
 static void main_view_offscreen_render_cb(void *data, uint32_t cx, uint32_t cy);
 
 static void register_offscreen_render(struct main_view_s *s)
@@ -47,6 +45,8 @@ static void unregister_offscreen_render(struct main_view_s *s)
 
 static void update(void *data, obs_data_t *settings)
 {
+	UNUSED_PARAMETER(settings);
+
 	struct main_view_s *s = data;
 
 	if (!s->offscreen_render)
@@ -56,8 +56,6 @@ static void update(void *data, obs_data_t *settings)
 
 static void *create(obs_data_t *settings, obs_source_t *source)
 {
-	UNUSED_PARAMETER(settings);
-
 	struct main_view_s *s = bzalloc(sizeof(struct main_view_s));
 
 	s->context = source;
@@ -204,7 +202,6 @@ const struct obs_source_info main_view_source = {
 	.create = create,
 	.destroy = destroy,
 	.get_properties = get_properties,
-	.get_defaults = get_defaults,
 	.update = update,
 	.video_tick = video_tick,
 	.video_render = video_render,

--- a/src/main-view-source.c
+++ b/src/main-view-source.c
@@ -6,7 +6,7 @@
 struct main_view_s
 {
 	obs_source_t *context;
-	bool rendering;
+	bool rendered;
 
 	obs_weak_source_t *weak_source;
 
@@ -92,6 +92,8 @@ static void video_tick(void *data, float seconds)
 	obs_source_t *target = obs_get_output_source(0);
 	s->weak_source = obs_source_get_weak_source(target);
 	obs_source_release(target);
+
+	s->rendered = false;
 }
 
 static void cache_video(struct main_view_s *s, obs_source_t *target)
@@ -152,12 +154,15 @@ static void main_view_offscreen_render_cb(void *data, uint32_t cx, uint32_t cy)
 	if (!obs_source_showing(s->context))
 		return;
 
+	// When virtual camera is enabled with scene or source type, this callback is called twice or more.
+	if (s->rendered)
+		return;
+	s->rendered = true;
+
 	obs_source_t *target = obs_weak_source_get_source(s->weak_source);
 	if (target) {
-		s->rendering = true;
 		cache_video(s, target);
 		obs_source_release(target);
-		s->rendering = false;
 	}
 }
 


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

When virtual camera of a scene or a source is enabled, the 2nd main-view is enabled and the main render callback is called twice. To avoid the 2nd rendering, set `rendered` variable.

Also removes an unused variable `rendering`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
