### PR TITLE
Use main rendered callback instead of main rendering callback

### DIFF
--- a/src/main-view-source.c
+++ b/src/main-view-source.c
@@ -68,13 +68,15 @@ static void destroy(void *data)
 {
 	struct main_view_s *s = data;
 
+	if (s->offscreen_render)
+		unregister_offscreen_render(s);
+
 	obs_weak_source_release(s->weak_source);
+
 	obs_enter_graphics();
 	gs_texrender_destroy(s->texrender);
 	gs_texrender_destroy(s->texrender_prev);
 	obs_leave_graphics();
-	if (s->offscreen_render)
-		unregister_offscreen_render(s);
 
 	bfree(s);
 }


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The main texture is available in the main rendered callback, which was introduced in OBS 29.1.
This is more efficient than re-rendering the source that is displayed on the main view.

Also fixes potential danging pointer access by moving the callback-unregister before releasing other objects

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
